### PR TITLE
fix: add `version` to `bu.sublime-syntax`

### DIFF
--- a/bu.sublime-syntax
+++ b/bu.sublime-syntax
@@ -1,5 +1,6 @@
 %YAML 1.2
 ---
+version: 2
 name: Butane
 file_extensions: [bu]
 extends: Packages/YAML/YAML.sublime-syntax


### PR DESCRIPTION
`version` needs to be the same as in `YAML.sublime-syntax`, cf [this StackOverflow question and answer](https://stackoverflow.com/questions/72036617/can-i-append-custom-highlights-to-an-existing-syntax-without-forking-it).

I have tested this in Sublime Text 4143.